### PR TITLE
Implement profile view with posts and likes

### DIFF
--- a/apps/posts/models.py
+++ b/apps/posts/models.py
@@ -32,16 +32,16 @@ class Post(models.Model):
     
     def toggle_like_by(self, user):
         from apps.likes.models import Like
-        like = Like.objects.filter(user=user).first()
-        
+        like = Like.objects.filter(user=user, post=self).first()
+
         if like:
             like.delete()
         else:
             Like.objects.create(user=user, post=self)
-            
+
     def toggle_pin_by(self, user):
-        pin = Pin.objects.filter(user=user).first()
-        
+        pin = Pin.objects.filter(user=user, post=self).first()
+
         if pin:
             pin.delete()
         else:
@@ -61,5 +61,4 @@ class Post(models.Model):
     def get_posts(cls, user=None):
         if user:
             return cls.objects.filter(author=user)
-        
         return cls.objects.all()

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -44,6 +44,7 @@ def profile_likes(request, username):
         "profile_user": profile_user,
         "liked_posts": liked_posts,
         "likes_count": liked_posts.count(),
+        "posts_count": profile_user.posts.count(),
         "active_tab": "likes",
     }
     return render(request, "apps/user/profile/tab_likes.html", ctx)

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,20 +5,19 @@ from django.contrib.auth.views import LoginView, LogoutView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('login/', LoginView.as_view(redirect_authenticated_user=True, template_name='apps/user/login.html'), name='login'), 
-    path('logout/', LogoutView.as_view(), name='logout'), 
+    path('login/', LoginView.as_view(redirect_authenticated_user=True, template_name='apps/user/login.html'), name='login'),
+    path('logout/', LogoutView.as_view(), name='logout'),
 
     # 投稿タイムライン & CRUD
-    path('', include(('apps.posts.urls', 'posts'), namespace='posts')),  
-
-    # 動的ユーザールートは最後に！
-    path('<str:username>/', include(('apps.users.urls', 'users'), namespace='users')),
-
+    path('', include(('apps.posts.urls', 'posts'), namespace='posts')),
+    
     # 一般的な likes API
     path('likes/', include(('apps.likes.urls', 'likes'), namespace='likes')),
     path('pins/', include(('apps.pins.urls', 'pins'), namespace='pins')),
-    
-    # # 個人ページ
-    # path('<str:username>/likes', views.my_likes, name='my_likes'), 
-    path('comments/', include(('apps.comments.urls', 'comments'), namespace='comments')), 
+
+    # コメント
+    path('comments/', include(('apps.comments.urls', 'comments'), namespace='comments')),
+
+    # 動的ユーザールートは最後に！
+    path('<str:username>/', include(('apps.users.urls', 'users'), namespace='users')),
 ]

--- a/templates/apps/user/profile/_profile_header.html
+++ b/templates/apps/user/profile/_profile_header.html
@@ -1,52 +1,29 @@
-{# プロフィールヘッダー専用パーシャル #}
+{# プロフィールヘッダー #}
 <div class="profile-header">
     <div class="cover-section">
         <div class="cover-image"></div>
         <div class="profile-avatar">
             <img src="/placeholder.svg?height=120&width=120" alt="プロフィール画像">
-            <div class="status-indicator"></div>
         </div>
     </div>
     <div class="profile-info">
-        <div class="profile-main">
-            <div class="name-section">
-                <h1 class="display-name">{{ profile_user.username }}</h1>
-                <span class="username">@{{ profile_user.username }}</span>
-                {% if profile_user.is_verified %}
-                    <div class="verified-badge">✓</div>
-                {% endif %}
-            </div>
-            {# 例としてボタンを残しておく — 必要に応じてビュー側で条件分岐 #}
-            <div class="action-buttons">
-                <button class="btn-secondary">メッセージ</button>
-                <button class="btn-primary">フォロー</button>
-                <button class="btn-icon">⋯</button>
-            </div>
+        <div class="name-section">
+            <h1 class="display-name">{{ profile_user.username }}</h1>
+            <span class="username">@{{ profile_user.username }}</span>
         </div>
-        <div class="bio-section">
-            {% if profile_user.bio %}
-                <p class="bio">{{ profile_user.bio|linebreaksbr }}</p>
-            {% endif %}
-            <div class="profile-links">
-                {% if profile_user.website %}
-                    <a href="{{ profile_user.website }}" class="profile-link">{{ profile_user.website }}</a>
-                {% endif %}
-                <span class="join-date">{{ profile_user.date_joined|date:"Y年n月に参加" }}</span>
-            </div>
+        <div class="profile-links">
+            <span class="join-date">{{ profile_user.date_joined|date:"Y年n月に参加" }}</span>
         </div>
         <div class="stats-section">
-            <div class="stat-item">
-                <span class="stat-number">{{ profile_user.following.count }}</span>
-                <span class="stat-label">フォロー中</span>
-            </div>
-            <div class="stat-item">
-                <span class="stat-number">{{ profile_user.followers.count }}</span>
-                <span class="stat-label">フォロワー</span>
-            </div>
             <div class="stat-item">
                 <span class="stat-number">{{ posts_count }}</span>
                 <span class="stat-label">投稿</span>
             </div>
+            <div class="stat-item">
+                <span class="stat-number">{{ likes_count }}</span>
+                <span class="stat-label">いいね</span>
+            </div>
         </div>
     </div>
 </div>
+

--- a/templates/apps/user/profile/base_profile.html
+++ b/templates/apps/user/profile/base_profile.html
@@ -11,7 +11,7 @@
 <div class="container">
 
     {# ① プロフィール共通ヘッダー #}
-    {% include 'apps/user/profile/_profile_header.html' with profile_user=profile_user %}
+    {% include 'apps/user/profile/_profile_header.html' with profile_user=profile_user posts_count=posts_count likes_count=likes_count %}
 
     {# ② タブナビゲーション #}
     <nav class="tabs-container">

--- a/templates/apps/user/profile/tab_likes.html
+++ b/templates/apps/user/profile/tab_likes.html
@@ -4,7 +4,7 @@
     {% for post in liked_posts %}
         <div class="post-card">
             <div class="post-header">
-                <img src="{{ post.author.avatar.url }}" alt="" class="post-avatar">
+                <img src="/placeholder.svg?height=40&width=40" alt="" class="post-avatar">
                 <div class="post-meta">
                     <div class="post-author">
                         <span class="author-name">{{ post.author.username }}</span>

--- a/templates/apps/user/profile/tab_posts.html
+++ b/templates/apps/user/profile/tab_posts.html
@@ -5,7 +5,7 @@
         {# 投稿カードをコンポーネント化している場合は include でもOK #}
         <div class="post-card">
             <div class="post-header">
-                <img src="{{ post.author.avatar.url }}" alt="" class="post-avatar">
+                <img src="/placeholder.svg?height=40&width=40" alt="" class="post-avatar">
                 <div class="post-meta">
                     <div class="post-author">
                         <span class="author-name">{{ post.author.username }}</span>


### PR DESCRIPTION
## Summary
- Place dynamic user routing last so API endpoints like `/likes/` remain reachable
- Fix Post model helpers to toggle likes and pins per post
- Simplify profile templates and header to avoid missing User attributes and show post/like counts

## Testing
- `python manage.py test` *(failed: ModuleNotFoundError: No module named 'django')*
- `pip install django==5.1.3` *(failed: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68972648cd848332aa546c05a4202c99